### PR TITLE
Add a placeholder on the profile page if the user has no image

### DIFF
--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -55,7 +55,3 @@ body {
   display: -webkit-box;
   -webkit-box-orient: vertical;
 }
-
-.user-info {
-  min-width: 800px;
-}


### PR DESCRIPTION
If the user has no image set in their profile, a broken img tag is the result. This PR adds a placeholder image on the profile page if the image is missing.